### PR TITLE
Added tests that UrlGuard correctly identifies unsafe URLs. These tests…

### DIFF
--- a/ReviveIT/Application/Common/Exceptions/UrlGuard.cs
+++ b/ReviveIT/Application/Common/Exceptions/UrlGuard.cs
@@ -13,10 +13,10 @@ namespace Application.Common.Exceptions
             public UnsafeUrlException(string message) : base(message) { }
         }
         private static readonly List<string> unsafePatterns = new List<string>
-    {
-        "malware", "phishing", "hacker","virus", "trojan", "exploit", "attack", "unauthorized",
-        "#", "%", "<", ">", "{", "}", "-", "=", "`", "&", "*", "?", "!", "\"", ";", ":", "'", "+", "@"
-    };
+        {
+            "malware", "phishing", "hacker", "virus", "trojan", "exploit", "attack", "unauthorized",
+            "#", "%", "<", ">", "{", "}", "-", "=", "`", "&", "*", "?", "!", ";", "'", "+", "@"
+        };
         public static bool IsUnsafeUrl(string url)
         {
             foreach (var pattern in unsafePatterns)

--- a/ReviveIT/ReviveIt.test/ExceptionMiddlewareTests.cs
+++ b/ReviveIT/ReviveIt.test/ExceptionMiddlewareTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using WebUI.MiddleWares;
+using Xunit;
+
+namespace Application.Tests
+{
+    public class ExceptionMiddlewareTests
+    {
+        private readonly Mock<ILogger<ExceptionMiddleware>> _loggerMock;
+        private readonly RequestDelegate _next;
+
+        public ExceptionMiddlewareTests()
+        {
+            _loggerMock = new Mock<ILogger<ExceptionMiddleware>>();
+            _next = (HttpContext context) => Task.CompletedTask;
+        }
+
+        [Theory]
+        [InlineData("?url=http://localhost/malware", HttpStatusCode.BadRequest)]
+        [InlineData("?url=http://localhost/--", HttpStatusCode.BadRequest)]
+        [InlineData("?url=http://localhost/normal", HttpStatusCode.OK)]
+        public async Task Invoke_ShouldReturnAccurateResponse(string queryString, HttpStatusCode expectedStatusCode)
+        {
+            var context = new DefaultHttpContext();
+            context.Request.QueryString = new QueryString(queryString);
+
+            var middleware = new ExceptionMiddleware(_next, _loggerMock.Object);
+
+            await middleware.Invoke(context);
+
+            Assert.Equal((int)expectedStatusCode, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Invoke_ShouldCheckUrlBeforeProceedingToNextMiddleware()
+        {
+            var context = new DefaultHttpContext();
+            context.Request.QueryString = new QueryString("?url=http://localhost/malware");
+
+            bool nextMiddlewareInvoked = false;
+
+            var middleware = new ExceptionMiddleware(async (innerContext) =>
+            {
+                nextMiddlewareInvoked = true;
+                innerContext.Response.StatusCode = (int)HttpStatusCode.OK;
+                await Task.CompletedTask;
+            }, _loggerMock.Object);
+
+            await middleware.Invoke(context);
+
+            Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
+            Assert.False(nextMiddlewareInvoked);
+        }
+    }
+}

--- a/ReviveIT/ReviveIt.test/UrlGuardTests.cs
+++ b/ReviveIT/ReviveIt.test/UrlGuardTests.cs
@@ -1,0 +1,43 @@
+﻿using Application.Common.Exceptions;
+using Xunit;
+
+namespace Application.Tests
+{
+    public class UrlGuardTests
+    {
+        [Theory]
+        [InlineData("http://localhost/malware", true)]
+        [InlineData("http://localhost/phishing", true)]
+        [InlineData("http://localhost/hacker", true)]
+        [InlineData("http://localhost/virus", true)]
+        [InlineData("http://localhost/trojan", true)]
+        [InlineData("http://localhost/exploit", true)]
+        [InlineData("http://localhost/attack", true)]
+        [InlineData("http://localhost/unauthorized", true)]
+        [InlineData("http://localhost/#", true)]
+        [InlineData("http://localhost/%", true)]
+        [InlineData("http://localhost/<", true)]
+        [InlineData("http://localhost/>", true)]
+        [InlineData("http://localhost/{", true)]
+        [InlineData("http://localhost/}", true)]
+        [InlineData("http://localhost/-", true)]
+        [InlineData("http://localhost/=", true)]
+        [InlineData("http://localhost/`", true)]
+        [InlineData("http://localhost/&", true)]
+        [InlineData("http://localhost/*", true)]
+        [InlineData("http://localhost/?", true)]
+        [InlineData("http://localhost/!", true)]
+        [InlineData("http://localhost/;", true)]
+        [InlineData("http://localhost/'", true)]
+        [InlineData("http://localhost/+", true)]
+        [InlineData("http://localhost/@", true)]
+        [InlineData("http://localhost/normal", false)]
+        [InlineData("http://localhost/test", false)] 
+        public void UrlGuard_IsUnsafeUrl_ShouldIdentifyUnsafeUrls(string url, bool expected)
+        {
+            var result = UrlGuard.IsUnsafeUrl(url);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
… ensures that the URL check happens before any other middleware in the pipeline and that the next middleware is not called if the URL is unsafe