### PR TITLE
Added message_service and imessage_service to handle chat operations

### DIFF
--- a/ReviveIT/Application/Interfaces/IMessageService.cs
+++ b/ReviveIT/Application/Interfaces/IMessageService.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-
 namespace Application.Interfaces
 {
     public interface IMessageService

--- a/ReviveIT/Application/Interfaces/IMessageService.cs
+++ b/ReviveIT/Application/Interfaces/IMessageService.cs
@@ -1,0 +1,18 @@
+﻿using Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace Application.Interfaces
+{
+    public interface IMessageService
+    {
+        void SendMessage(string senderId, string receiverId, string message);
+        IEnumerable<ChatSession> GetChatSessions(string userId);
+        IEnumerable<Messages> GetChatHistory(int chatSessionId);
+        void MarkMessageAsRead(int messageId);
+    }
+}

--- a/ReviveIT/Infrastructure/Services/MessageService.cs
+++ b/ReviveIT/Infrastructure/Services/MessageService.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Application.Interfaces;
+using Infrastructure.Data;
+
+namespace Infrastructure.Services
+{
+    public class MessageService : IMessageService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public MessageService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public void SendMessage(string senderId, string receiverId, string message)
+        {
+            var chatSession = _context.ChatSessions.FirstOrDefault(cs =>
+                (cs.TechnicianId == senderId && cs.CustomerId == receiverId) ||
+                (cs.TechnicianId == receiverId && cs.CustomerId == senderId));
+
+            if (chatSession == null)
+            {
+                chatSession = new ChatSession
+                {
+                    TechnicianId = senderId,
+                    CustomerId = receiverId,
+                    StartTime = DateTime.UtcNow
+                };
+                _context.ChatSessions.Add(chatSession);
+                _context.SaveChanges();
+            }
+
+            var chatMessage = new Messages
+            {
+                ChatSessionId = chatSession.ChatSessionId,
+                SenderID = senderId,
+                RecipientID = receiverId,
+                MessageContent = message,
+                Timestamp = DateTime.UtcNow,
+                Viewed = false
+            };
+
+            _context.Messages.Add(chatMessage);
+            _context.SaveChanges();
+        }
+
+        public IEnumerable<ChatSession> GetChatSessions(string userId)
+        {
+            return _context.ChatSessions
+                .Where(cs => cs.TechnicianId == userId || cs.CustomerId == userId)
+                .Include(cs => cs.Messages)
+                .Include(cs => cs.Technician)
+                .Include(cs => cs.Customer)
+                .ToList();
+        }
+
+        public IEnumerable<Messages> GetChatHistory(int chatSessionId)
+        {
+            return _context.Messages
+                .Where(m => m.ChatSessionId == chatSessionId)
+                .OrderBy(m => m.Timestamp)
+                .Include(m => m.Sender)
+                .Include(m => m.Recipient)
+                .ToList();
+        }
+
+        public void MarkMessageAsRead(int messageId)
+        {
+            var message = _context.Messages.Find(messageId);
+            if (message != null)
+            {
+                message.Viewed = true;
+                _context.SaveChanges();
+            }
+        }
+    }
+}


### PR DESCRIPTION
IMessageService Interface
Defines the contract for message service operations:

SendMessage: Sends a message from a sender to a receiver.

GetChatSessions: Retrieves chat sessions for a specific user.

GetChatHistory: Gets the message history for a specific chat session.

MarkMessageAsRead: Marks a message as read.

MessageService Implementation
Provides the actual implementation of IMessageService:

SendMessage: Handles the logic for sending messages and creating chat sessions if they don’t exist.

GetChatSessions: Fetches chat sessions involving the specified user, including related message data.

GetChatHistory: Returns the ordered message history for a chat session.

MarkMessageAsRead: Updates the message status to indicate it has been viewed.